### PR TITLE
Fix Gene Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.1] – 2025-04-29
 
-## [v1.0.0] – 2025-04-29
+### Fixed
+
+- Use of a list of attributes to map protein id and gene in the GFF.
+
+## [v0.1.0] – 2025-04-29
 
 ### Added
 

--- a/tatouscan/annotation.py
+++ b/tatouscan/annotation.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Set
 import pyhmmer.easel
 import logging
 from rich.progress import track
@@ -93,7 +93,7 @@ def annotate_cdss(
         faa_file=faa_file, hmm_db=hmm_db, e_value_threshold=e_value_threshold
     )
     cds_from_gff_with_hits: List[Cds] = []
-
+    matching_ids: Set[str] = set()
     for contig_name, cds_list in get_cdss_from_gff_file(gff_file):
 
         for cds in cds_list:
@@ -101,11 +101,12 @@ def annotate_cdss(
                 if getattr(cds, attribute) in protein_id_to_hits:
                     cds.ta_hits = protein_id_to_hits[getattr(cds, attribute)]
                     cds_from_gff_with_hits.append(cds)
+                    matching_ids.add(getattr(cds, attribute))
                     break
 
         yield contig_name, cds_list
 
-    if len(cds_from_gff_with_hits) != len(protein_id_to_hits):
+    if len(cds_from_gff_with_hits) < len(protein_id_to_hits):
 
         logger.critical(
             f"{len(protein_id_to_hits)} proteins with TA hits were identified from the FAA file, "

--- a/tatouscan/main.py
+++ b/tatouscan/main.py
@@ -103,7 +103,7 @@ def main(
         "TAtouScan CLI is under development. Run `tatouscan --help` for available commands.",
         color=True,
     )
-    cds_protein_attr = ["id"]  # ["id", "protein_id", "name", "locus_tag"]
+    cds_protein_attr = ["id", "protein_id", "name", "locus_tag"]
 
     contig_name_and_cdss = annotate_cdss(
         gff_file=gff,


### PR DESCRIPTION
Protein ID mapping was only using the id attribute from the GFF file. It now also checks ["id", "protein_id", "name", "locus_tag"] to improve matching.

This was already coded but the feature was disabled. It’s now enabled and working.