### PR TITLE
make gene systems only when gene are on the same strand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use of a list of attributes to map protein id and gene in the GFF.
+- Improve protein id and gene id mapping using a list of attributes. 
 
 ## [v0.1.0] – 2025-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improve protein id and gene id mapping using a list of attributes. 
+- Improve protein id and gene id mapping using a list of attributes.
+- Group Genes in systems only when they are on the same strand.
 
 ## [v0.1.0] – 2025-04-29
 

--- a/tatouscan/system.py
+++ b/tatouscan/system.py
@@ -21,7 +21,9 @@ def group_cdss_with_ta_annotation(
             for cds_j in sorted_cdss_with_ta_hit[i + 1 :]:
 
                 if cds_i.distance_from(cds_j) <= max_distance:
-
+                    if cds_i.strand != cds_j.strand:
+                        # not grouping gene in systems from opposit strands
+                        continue
                     cds_i.add_neigbor_gene(cds_j)
 
                     cds_i.update_ta_cluster(cds_j)


### PR DESCRIPTION
Currently systems can be made of genes from different strand. however ta systems of type II are only made of gene on the same strands.

Added a condition to only group genes in systems when they are on the same strand. 