### PR TITLE
add scoring function on ta systems

### DIFF
--- a/.github/workflows/tatouscan_ci.yml
+++ b/.github/workflows/tatouscan_ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-13']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: [3.10, 3.13] 
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Scoring**: each predicted TA pair now receives a match score in `(0, 1]` comparing toxin size, antitoxin size, and intergenic distance against family-specific reference statistics derived from TADB3. A compatibility term penalises toxin–antitoxin family combinations not seen in TADB3. Scores use robust Z-scores (median + MAD) to handle skewed family distributions.
+- **Scoring**: each predicted TA pair now receives a match score in `(0, 1]` comparing toxin size, antitoxin size, and intergenic distance against family-specific reference statistics derived from TADB3. A compatibility term penalises toxin–antitoxin family combinations not seen in TADB3. Scores use Z-scores (median + MAD) to handle skewed family distributions.
 - **Second output file** `tatouscan_results_pairs.tsv`: one row per predicted TA pair, combining both gene annotations, structural features, and the pair score.
 - **`--db` flag**: replaces the previous separate arguments for HMM profiles and statistics files. A single database directory is now expected.
 - **`--detailed` flag**: by default only the single best HMM hit and final score are written; `--detailed` restores per-source HMM columns (TASmania, TADB3, Other) and raw Z-score columns.
-- **Multi-gene systems**: clusters with more than one toxin or antitoxin are now scored (best-scoring pair reported in the per-gene file; all combinations written as separate rows in the pairs file).
 
 ## [v0.1.1] – 2025-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Scoring**: each predicted TA pair now receives a match score in `(0, 1]` comparing toxin size, antitoxin size, and intergenic distance against family-specific reference statistics derived from TADB3. A compatibility term penalises toxin–antitoxin family combinations not seen in TADB3. Scores use robust Z-scores (median + MAD) to handle skewed family distributions.
+- **Second output file** `tatouscan_results_pairs.tsv`: one row per predicted TA pair, combining both gene annotations, structural features, and the pair score.
+- **`--db` flag**: replaces the previous separate arguments for HMM profiles and statistics files. A single database directory is now expected.
+- **`--detailed` flag**: by default only the single best HMM hit and final score are written; `--detailed` restores per-source HMM columns (TASmania, TADB3, Other) and raw Z-score columns.
+- **Multi-gene systems**: clusters with more than one toxin or antitoxin are now scored (best-scoring pair reported in the per-gene file; all combinations written as separate rows in the pairs file).
+
 ## [v0.1.1] – 2025-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,37 +56,54 @@ pip install -e .
 > TAtouScan is not yet available via `bioconda`. The above method combines `conda` for environment management and `pip` for installation.
 
 
-### Download TAtouScan HMM Database
+### Download the TAtouScan Database
 
-TAtouScan requires a database of HMM profiles to run. You can download the latest version from Zenodo:  
-🔗 https://zenodo.org/records/15305313
+TAtouScan requires a database directory containing HMM profiles and reference statistics.
 
-Download the required files using:
+> **TODO**: Upload the updated database to Zenodo and add the download link here.
 
+<!-- Once available, download and extract with:
 ```bash
-wget https://zenodo.org/records/15305313/files/tatouscan_hmm_description.tsv
-wget https://zenodo.org/records/15305313/files/tatouscan_hmm_profiles.hmm.gz
+wget https://zenodo.org/records/XXXXXXX/files/tatouscan_db.tar.gz
+tar -xzf tatouscan_db.tar.gz
+```
+-->
+
+The database directory must contain the following four files:
+
+```
+tatouscan_db/
+  ta.hmm                 # HMM profiles (HMMER3 format)
+  hmm_info.tsv           # profile metadata (name, type, source)
+  family_statistics.tsv  # per-family reference statistics for scoring
+  known_pairs.tsv        # known toxin–antitoxin family co-occurrences
 ```
 
 
 ## Usage
 
-After installation and downloading the required HMM database, you can run TAtouScan as follows:
+After installation and downloading the database, run TAtouScan with:
 
-TAtouScan currently requires:
 - a **GFF** file with gene annotations
 - a **FAA** file with the corresponding protein sequences
-
-To identify toxin-antitoxin systems in a genome, run:
+- the **database directory** downloaded above
 
 ```bash
-tatouscan --gff <genes.gff> --faa <proteins.faa> \
-  --hmm_db tatouscan_hmm_profiles.hmm.gz \
-  --hmm_info tatouscan_hmm_description.tsv
+tatouscan --gff <genes.gff> --faa <proteins.faa> --db tatouscan_db/
 ```
 
-This command will produce an output file named:  
-📄 `tatouscan_results.tsv` — listing all predicted toxins and antitoxins found in the input genome.
+By default, results are written to a directory called `tatouscan_results/`. Use `--outdir` to specify a different location:
+
+```bash
+tatouscan --gff <genes.gff> --faa <proteins.faa> --db tatouscan_db/ --outdir my_results/
+```
+
+Two TSV files are produced inside the output directory:
+
+| File | Description |
+|------|-------------|
+| `tatouscan_results.tsv` | One row per predicted toxin or antitoxin gene |
+| `tatouscan_results_pairs.tsv` | One row per predicted TA pair (two-gene systems only) |
 
 
 
@@ -113,31 +130,112 @@ The HMM database used by TAtouScan is composed of profiles collected from multip
 
 ## Output
 
-TAtouScan produces a TSV file (`tatouscan_results.tsv`) summarizing the predicted toxin-antitoxin (TA) genes. The file includes the following columns:
+TAtouScan writes two TSV files into the output directory.
 
-| Column Name                | Description                                                            |
-| -------------------------- | ---------------------------------------------------------------------- |
-| `contig_name`              | Name of the contig where the gene is located                           |
-| `gene_id`                  | Unique identifier of the gene (from the input GFF file)                |
-| `start`                    | Start position of the gene on the contig                               |
-| `end`                      | End position of the gene on the contig                                 |
-| `strand`                   | Strand of the gene (`+` or `-`)                                        |
-| `product`                  | Predicted function or product of the gene (if available)               |
-| `is_single_gene`           | Whether the gene is a single hit or part of a TA pair (`True`/`False`) |
-| `ta_system_id`             | ID of the TA system this gene belongs to (shared between paired genes) |
-| `gene_type`                | Type of gene: either `toxin` or `antitoxin`                            |
-| `TASmania_hmm_name`        | Name of the matched HMM profile from the TASmania database (if any)    |
-| `TASmania_hmm_score`       | Bit score of the TASmania HMM hit                                      |
-| `TASmania_hmm_evalue`      | E-value of the TASmania HMM hit                                        |
-| `TASmania_hmm_description` | Description of the TASmania HMM profile                                |
-| `Other_hmm_name`           | Name of a matched HMM profile from other sources (if any)              |
-| `Other_hmm_score`          | Bit score of the "Other" HMM hit                                       |
-| `Other_hmm_evalue`         | E-value of the "Other" HMM hit                                         |
-| `Other_hmm_description`    | Description of the HMM profile from other sources                      |
-| `TADB3_hmm_name`           | Name of the matched HMM profile from the TADB3 database (if any)       |
-| `TADB3_hmm_score`          | Bit score of the TADB3 HMM hit                                         |
-| `TADB3_hmm_evalue`         | E-value of the TADB3 HMM hit                                           |
-| `TADB3_hmm_description`    | Description of the TADB3 HMM profile                                   |
+By default, only the most informative columns are written. Add `--detailed` to include per-source HMM breakdowns and raw Z-score columns.
+
+### `tatouscan_results.tsv` — per-gene results
+
+One row per predicted toxin or antitoxin gene.
+
+| Column | Description |
+|--------|-------------|
+| `contig_name` | Contig where the gene is located |
+| `gene_id` | Gene identifier (from the input GFF) |
+| `start` / `end` | Genomic coordinates |
+| `strand` | `+` or `-` |
+| `length_aa` | Protein length in amino acids |
+| `product` | Predicted gene product (if available) |
+| `ta_system_id` | ID shared by both genes of a pair (`None` for single-gene predictions) |
+| `is_single_gene` | `True` if no paired partner was found |
+| `gene_type` | `Toxin` or `Antitoxin` |
+| `hmm_name` / `hmm_score` / `hmm_evalue` | Best HMM hit across all database sources |
+| `hmm_source` | Database the best hit comes from (`TADB3`, `TASmania`, or other) |
+| `hmm_description` | Profile description |
+| `pair_is_known` | `1` if this toxin–antitoxin family combination is known in TADB3, `0` if not, `None` if family could not be identified |
+| `score` | Unified match score in `(0, 1]` (see [Scoring](#scoring)) |
+
+Scoring columns are `None` for single-gene predictions.
+
+### `tatouscan_results_pairs.tsv` — per-pair results
+
+One row per predicted toxin–antitoxin pair. For systems with more than one toxin or antitoxin, all valid combinations are written as separate rows.
+
+| Column | Description |
+|--------|-------------|
+| `ta_system_id` | Shared system ID (matches the per-gene file) |
+| `contig_name` | Contig where the pair is located |
+| `toxin_gene_id` | Toxin gene identifier |
+| `toxin_strand` | `+` or `-` |
+| `toxin_product` | Predicted gene product |
+| `toxin_length_aa` | Toxin protein length in amino acids |
+| `toxin_hmm_name` / `_score` / `_evalue` / `_source` / `_description` | Best HMM hit for the toxin |
+| `antitoxin_gene_id` | Antitoxin gene identifier |
+| `antitoxin_strand` | `+` or `-` |
+| `antitoxin_product` | Predicted gene product |
+| `antitoxin_length_aa` | Antitoxin protein length in amino acids |
+| `antitoxin_hmm_name` / `_score` / `_evalue` / `_source` / `_description` | Best HMM hit for the antitoxin |
+| `intergenic_distance` | Distance in nucleotides between the two genes (negative = overlap) |
+| `pair_is_known` | `1` / `0` / `None` (see above) |
+| `score` | Unified match score in `(0, 1]` |
+
+### Detailed output
+
+With `--detailed`, the following additional columns are written to both files:
+
+- **Per-source HMM hits**: `TASmania_hmm_name/score/evalue/description`, `TADB3_hmm_name/score/evalue/description`, `Other_hmm_name/score/evalue/description` (prefixed with `toxin_` / `antitoxin_` in the pairs file)
+- **Raw Z-scores**: `toxin_size_z`, `at_size_z`, `intergenic_distance_z`, `matched_family`, `n_reference_pairs`
+
+The pairs file also adds `toxin_start/end` and `antitoxin_start/end` in detailed mode.
+
+---
+
+## Scoring
+
+Every predicted TA **pair** is compared against reference statistics derived from known TADB3 type-II systems. The score measures how closely the predicted pair resembles a genuine TA system of its family.
+
+### What is compared
+
+Three structural features are measured for each predicted pair and compared against the reference distribution for the matched family:
+
+| Feature | Definition |
+|---------|------------|
+| `toxin_size` | Toxin protein length (amino acids) |
+| `at_size` | Antitoxin protein length (amino acids) |
+| `intergenic_distance` | Distance in nucleotides between the two genes (negative = overlap) |
+
+The **toxin family** is determined from its best TADB3 HMM hit. If no TADB3 hit exists or the family has fewer than 20 reference pairs, global statistics computed across all families are used as a fallback.
+
+### Robust Z-scores
+
+For each feature, a Z-score measures how far the predicted value deviates from the family reference:
+
+$$z = \frac{x - \text{median}}{\text{MAD} / 0.6745}$$
+
+Median and MAD (median absolute deviation) are used instead of mean and standard deviation because size distributions in TA families are often skewed. This makes the scores robust to outliers.
+
+### Unified score
+
+All Z-scores are combined into a single **score** in the range $(0, 1]$:
+
+$$\text{score} = \exp\!\left(-\frac{1}{n}\sum_i |z_i|\right)$$
+
+The mean is taken over all available terms: the three structural Z-scores plus a **compatibility term** ($z_{\text{compat}}$) based on whether this toxin–antitoxin family combination has been observed in TADB3:
+
+- `pair_is_known = 1` → $z_{\text{compat}} = 0$ (no penalty)
+- `pair_is_known = 0` → $z_{\text{compat}} = 2$ (unknown combination lowers the score)
+- `pair_is_known = None` → compatibility term excluded from the mean
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| ~1.0 | Features match the family reference almost exactly, known combination |
+| ~0.7 | Moderate structural match, known combination |
+| ~0.4 | Moderate structural match, but family combination not seen in TADB3 |
+| < 0.2 | Large structural deviations or unknown combination — treat with caution |
+
+A high score supports a genuine TA pair; a low score does not exclude it, but suggests the prediction should be reviewed.
 
 
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Two TSV files are produced inside the output directory:
 
 ## HMM Database Composition
 
-The HMM database used by TAtouScan is composed of profiles collected from multiple sources, including curated databases and literature. The file `tatouscan_hmm_description.tsv` provides metadata for each profile, indicating its origin and whether it corresponds to a **toxin** or an **antitoxin**.
+The HMM database used by TAtouScan is composed of profiles collected from multiple sources, including curated databases and literature. The file `hmm_info.tsv` provides metadata for each profile, indicating its origin and whether it corresponds to a **toxin** or an **antitoxin**.
 
 ### Breakdown of the database:
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,12 @@ pip install -e .
 
 TAtouScan requires a database directory containing HMM profiles and reference statistics.
 
-> **TODO**: Upload the updated database to Zenodo and add the download link here.
 
-<!-- Once available, download and extract with:
+Download the database and extract it with:
 ```bash
-wget https://zenodo.org/records/XXXXXXX/files/tatouscan_db.tar.gz
+wget https://zenodo.org/records/20059258/files/tatouscan_db.tar.gz
 tar -xzf tatouscan_db.tar.gz
 ```
--->
 
 The database directory must contain the following four files:
 

--- a/tatouscan/database.py
+++ b/tatouscan/database.py
@@ -24,9 +24,9 @@ from pathlib import Path
 
 # Fixed filenames inside the database directory.
 DB_FILENAMES: dict[str, str] = {
-    "hmm_db":      "ta.hmm",
-    "hmm_info":    "hmm_info.tsv",
-    "ref_stats":   "family_statistics.tsv",
+    "hmm_db": "ta.hmm",
+    "hmm_info": "hmm_info.tsv",
+    "ref_stats": "family_statistics.tsv",
     "known_pairs": "known_pairs.tsv",
 }
 
@@ -34,9 +34,10 @@ DB_FILENAMES: dict[str, str] = {
 @dataclass(frozen=True)
 class TAtouScanDB:
     """Resolved paths to the four components of a TAtouScan database directory."""
-    hmm_db:      Path
-    hmm_info:    Path
-    ref_stats:   Path
+
+    hmm_db: Path
+    hmm_info: Path
+    ref_stats: Path
     known_pairs: Path
 
 
@@ -58,11 +59,7 @@ def load_db(path: Path) -> TAtouScanDB:
             "If you have a .tar.gz archive, extract it first: tar -xzf <archive>"
         )
 
-    missing = [
-        fname
-        for fname in DB_FILENAMES.values()
-        if not (path / fname).exists()
-    ]
+    missing = [fname for fname in DB_FILENAMES.values() if not (path / fname).exists()]
     if missing:
         raise FileNotFoundError(
             f"TAtouScan database at '{path}' is missing required file(s): "
@@ -71,8 +68,8 @@ def load_db(path: Path) -> TAtouScanDB:
         )
 
     return TAtouScanDB(
-        hmm_db      = path / DB_FILENAMES["hmm_db"],
-        hmm_info    = path / DB_FILENAMES["hmm_info"],
-        ref_stats   = path / DB_FILENAMES["ref_stats"],
-        known_pairs = path / DB_FILENAMES["known_pairs"],
+        hmm_db=path / DB_FILENAMES["hmm_db"],
+        hmm_info=path / DB_FILENAMES["hmm_info"],
+        ref_stats=path / DB_FILENAMES["ref_stats"],
+        known_pairs=path / DB_FILENAMES["known_pairs"],
     )

--- a/tatouscan/database.py
+++ b/tatouscan/database.py
@@ -1,0 +1,78 @@
+"""
+database.py – TAtouScan reference database loader.
+
+A TAtouScan database is a directory containing four fixed files:
+
+    ta.hmm                  HMMER3 HMM profiles (toxin + antitoxin)
+    hmm_info.tsv            HMM metadata (name, type, source, …)
+    family_statistics.tsv   Per-family reference statistics for scoring
+    known_pairs.tsv         Known (toxin_family, AT_family) co-occurrence pairs
+
+The directory is typically distributed as a .tar.gz archive that users
+extract once before running TAtouScan.  Pass the extracted directory to
+the ``--db`` CLI option.
+
+Example::
+
+    tatouscan --db /path/to/tatouscan_db/ --gff genome.gff --faa genome.faa …
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# Fixed filenames inside the database directory.
+DB_FILENAMES: dict[str, str] = {
+    "hmm_db":      "ta.hmm",
+    "hmm_info":    "hmm_info.tsv",
+    "ref_stats":   "family_statistics.tsv",
+    "known_pairs": "known_pairs.tsv",
+}
+
+
+@dataclass(frozen=True)
+class TAtouScanDB:
+    """Resolved paths to the four components of a TAtouScan database directory."""
+    hmm_db:      Path
+    hmm_info:    Path
+    ref_stats:   Path
+    known_pairs: Path
+
+
+def load_db(path: Path) -> TAtouScanDB:
+    """Validate *path* as a TAtouScan database directory and return resolved paths.
+
+    Raises
+    ------
+    NotADirectoryError
+        If *path* does not exist or is not a directory.
+    FileNotFoundError
+        If any of the four required files is missing from the directory.
+    """
+    if not path.exists():
+        raise NotADirectoryError(f"Database path does not exist: {path}")
+    if not path.is_dir():
+        raise NotADirectoryError(
+            f"--db must point to a directory (not a file): {path}\n"
+            "If you have a .tar.gz archive, extract it first: tar -xzf <archive>"
+        )
+
+    missing = [
+        fname
+        for fname in DB_FILENAMES.values()
+        if not (path / fname).exists()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"TAtouScan database at '{path}' is missing required file(s): "
+            + ", ".join(missing)
+            + f"\nExpected: {', '.join(DB_FILENAMES.values())}"
+        )
+
+    return TAtouScanDB(
+        hmm_db      = path / DB_FILENAMES["hmm_db"],
+        hmm_info    = path / DB_FILENAMES["hmm_info"],
+        ref_stats   = path / DB_FILENAMES["ref_stats"],
+        known_pairs = path / DB_FILENAMES["known_pairs"],
+    )

--- a/tatouscan/main.py
+++ b/tatouscan/main.py
@@ -11,12 +11,17 @@ from pathlib import Path
 from tatouscan.annotation import annotate_cdss, parse_hmm_db_info
 from tatouscan.system import group_cdss_with_ta_annotation
 from tatouscan.writer import write_gene_with_ta_annotation
+from tatouscan.scoring import load_reference_statistics, load_known_pairs
+from tatouscan.database import load_db
 
 logger = logging.getLogger(__name__)
 
 app = typer.Typer(
-    help="TAtouScan: A tool for identifying toxin-antitoxin (TA) systems.",
+    name="TAtouScan",
+    help=f"TAtouScan {__version__}: A tool for identifying toxin-antitoxin (TA) systems.",
     context_settings={"help_option_names": ["-h", "--help"]},
+    add_completion=False,
+    rich_markup_mode="rich",
 )
 
 
@@ -35,6 +40,8 @@ def main(
             "--gff",
             help="Path to the GFF file containing gene annotations.",
             exists=True,
+            file_okay=True,
+            dir_okay=False,
         ),
     ],
     faa: Annotated[
@@ -43,31 +50,34 @@ def main(
             "--faa",
             help="Path to the FASTA file containing protein sequences.",
             exists=True,
+            file_okay=True,
+            dir_okay=False,
         ),
     ],
-    hmm_db: Annotated[
+    db: Annotated[
         Path,
         typer.Option(
-            "--hmm_db",
-            help="Path to the HMM database file.",
+            "--db",
+            help=(
+                "Path to the TAtouScan database directory containing: "
+                "ta.hmm, hmm_info.tsv, family_statistics.tsv, known_pairs.tsv. "
+                "Typically obtained by extracting the distributed .tar.gz archive."
+            ),
             exists=True,
+            file_okay=False,
+            dir_okay=True,
         ),
     ],
-    hmm_info: Annotated[
+    outdir: Annotated[
         Path,
         typer.Option(
-            "--hmm_info",
-            help="Path to a TSV containing informaiton on the HMM profile.",
-            exists=True,
+            "-o",
+            "--outdir",
+            help="Directory where output TSV files will be written.",
+            file_okay=False,
+            dir_okay=True,
         ),
-    ],
-    output_file: Annotated[
-        Path,
-        typer.Option(
-            "--output",
-            help="Path to a TSV file to write the gene with TA annotation.",
-        ),
-    ] = Path("tatouscan_results.tsv"),
+    ] = Path("tatouscan_results"),
     max_distance: Annotated[
         int,
         typer.Option(
@@ -80,6 +90,17 @@ def main(
             help="Maximum E-value for TA hits to be considered.",
         ),
     ] = 0.005,
+    detailed: Annotated[
+        bool,
+        typer.Option(
+            "--detailed",
+            help=(
+                "Write all per-source HMM columns (TASmania, TADB3, Other) and "
+                "raw Z-score columns in the output files. "
+                "By default only the single best HMM hit and the final score are written."
+            ),
+        ),
+    ] = False,
     version: Annotated[
         Optional[bool],
         typer.Option(
@@ -100,15 +121,17 @@ def main(
 
     """Main entry point for TAtouScan CLI."""
     typer.echo(
-        "TAtouScan CLI is under development. Run `tatouscan --help` for available commands.",
+        "TAtouScan CLI is under development. Run `tatouscan --help` for available parameters.",
         color=True,
     )
     cds_protein_attr = ["id", "protein_id", "name", "locus_tag"]
 
+    tatouscan_db = load_db(db)
+
     contig_name_and_cdss = annotate_cdss(
         gff_file=gff,
         faa_file=faa,
-        hmm_db=hmm_db,
+        hmm_db=tatouscan_db.hmm_db,
         e_value_threshold=max_e_value,
         matching_attributes=cds_protein_attr,
     )
@@ -117,10 +140,23 @@ def main(
         contig_name_and_cdss, max_distance
     )
 
-    hmm_name_to_info = parse_hmm_db_info(hmm_info_file=hmm_info)
+    hmm_name_to_info = parse_hmm_db_info(hmm_info_file=tatouscan_db.hmm_info)
+
+    ref_stats = load_reference_statistics(tatouscan_db.ref_stats)
+    known_pairs_set = load_known_pairs(tatouscan_db.known_pairs)
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    output_file = outdir / "tatouscan_results.tsv"
+    output_pairs_file = outdir / "tatouscan_results_pairs.tsv"
 
     write_gene_with_ta_annotation(
-        contig_name_and_cdss_with_ta_hit, hmm_name_to_info, output_file
+        contig_name_and_cdss_with_ta_hit,
+        hmm_name_to_info,
+        output_file,
+        ref_stats,
+        known_pairs_set,
+        output_pairs_file=output_pairs_file,
+        detailed=detailed,
     )
 
 

--- a/tatouscan/parser.py
+++ b/tatouscan/parser.py
@@ -16,7 +16,7 @@ def parse_gff_attributes(attribute_str: str) -> Dict[str, str]:
     attributes_dict: Dict[str, str] = {}
     for attribute in attributes:
         try:
-            (key, value) = attribute.strip().split("=")
+            key, value = attribute.strip().split("=")
             attributes_dict[key.upper()] = value
         except ValueError:
             pass  # we assume that it is a strange, but useless field for our analysis

--- a/tatouscan/scoring.py
+++ b/tatouscan/scoring.py
@@ -1,0 +1,327 @@
+"""
+scoring.py – Family-aware robust Z-score scoring of putative TA pairs.
+
+For each two-gene cluster, compares three structural features
+(toxin length, antitoxin length, intergenic distance) against the
+distribution observed in known TADB3 systems.  Features are normalised
+by family-specific reference statistics when available, falling back to
+global statistics for rare or unrecognised families.
+
+Robust Z-score (median + MAD)
+------------------------------
+    z_robust = (x − median) / (MAD / 0.6745)
+
+The 0.6745 factor (= Φ⁻¹(0.75)) makes MAD equivalent to σ for normally
+distributed data, so scores are directly comparable to classic Z-scores.
+Unlike mean + std, median and MAD are unaffected by outliers and skewed
+tails — which is important here because many TA families have non-normal
+size distributions.
+
+Unified score
+-------------
+    score = exp(−mean(|z_i|))
+
+The mean is taken over all available z-score terms:
+  • toxin_size_z, at_size_z, intergenic_distance_z  (structural features)
+  • z_compat: 0 if the (toxin, AT) pair is known in TADB3,
+              COMPAT_PENALTY (default 2.0) if the pair is unknown,
+              excluded from the mean if family identity is unavailable.
+
+Range: (0, 1].  1 = perfect match to the family median, known pair.
+The exponential transform preserves ranking while giving an intuitive
+[0, 1] scale for users.
+"""
+
+from __future__ import annotations
+
+import csv
+import itertools
+import math
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+
+from tatouscan.models import Cds, GeneCluster
+
+# Features that are scored; names must match columns in the reference TSV
+# and the keys returned in the score dict.
+SCORED_FEATURES = ("toxin_size", "at_size", "intergenic_distance")
+
+# Sentinel used for the global fallback row in the reference stats file
+GLOBAL_FAMILY = "__global__"
+
+# Family statistics type:
+#   family → "n_pairs" → int
+#   family → feature   → (center, scale)
+#                         center = median (or mean for old TSVs)
+#                         scale  = MAD/0.6745 (or std for old TSVs / MAD=0 fallback)
+RefStats = Dict[str, Dict[str, Any]]
+
+# HMM database metadata: hmm_name → {"type", "source", "supplementary_info", ...}
+HmmDbInfo = Dict[str, Dict[str, str]]
+
+# Known toxin–antitoxin family co-occurrence pairs from TADB3.
+# Each element is (toxin_family, at_family).
+KnownPairs = FrozenSet[Tuple[str, str]]
+
+# Z-score equivalent penalty applied when a (toxin, AT) family pair is
+# not found in the TADB3 known-pairs set.  2.0 means "an unknown pair is
+# treated as a 2-sigma structural mismatch" in the unified score.
+COMPAT_PENALTY = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Loading reference data
+# ---------------------------------------------------------------------------
+
+def load_reference_statistics(path: Path) -> RefStats:
+    """Load per-family reference statistics from *tadb3_family_statistics.tsv*.
+
+    Prefers robust statistics (median + MAD) when the columns
+    ``{feat}_median`` and ``{feat}_mad`` are present (produced by
+    ``build_reference_features.py`` ≥ v2).  Falls back to mean + std for
+    older TSV files that lack those columns.
+
+    When MAD = 0 (e.g. a family where all representatives have identical
+    values), falls back to std for that feature so that ``_z_score`` can
+    still return a useful value rather than *None*.
+
+    Returns a dict:  family → feature → (center, scale)
+    Where center = median (or mean) and scale = MAD/0.6745 (or std).
+    The special key ``"__global__"`` holds the global-fallback stats.
+    """
+    MAD_CONSISTENCY = 0.6745  # Φ⁻¹(0.75): makes MAD ≡ σ for normal data
+
+    stats: RefStats = {}
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        fieldnames = reader.fieldnames or []
+        has_robust = all(
+            f"{feat}_median" in fieldnames and f"{feat}_mad" in fieldnames
+            for feat in SCORED_FEATURES
+        )
+        for row in reader:
+            family = row["family"]
+            entry: Dict[str, Any] = {}
+            for feat in SCORED_FEATURES:
+                if has_robust:
+                    center = float(row[f"{feat}_median"])
+                    mad    = float(row[f"{feat}_mad"])
+                    scale  = mad / MAD_CONSISTENCY
+                    if scale == 0.0:
+                        # MAD=0: all values identical — fall back to std
+                        scale = float(row.get(f"{feat}_std", 0.0))
+                else:
+                    center = float(row[f"{feat}_mean"])
+                    scale  = float(row[f"{feat}_std"])
+                entry[feat] = (center, scale)
+            entry["n_pairs"] = int(row["n_pairs"])
+            stats[family] = entry
+    return stats
+
+
+def load_known_pairs(path: Path) -> KnownPairs:
+    """Load the set of known (toxin_family, at_family) co-occurrence pairs.
+
+    Reads *tadb3_known_pairs.tsv* produced by build_compatibility_matrix.py.
+    Each row must have at minimum the columns ``toxin_family`` and ``at_family``.
+    """
+    pairs: Set[Tuple[str, str]] = set()
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for row in reader:
+            pairs.add((row["toxin_family"], row["at_family"]))
+    return frozenset(pairs)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def get_gene_type(cds: Cds, hmm_db_info: HmmDbInfo) -> Optional[str]:
+    """Return the type string (``"Toxin"`` or ``"Antitoxin"``) for *cds*."""
+    if not cds.ta_hits:
+        return None
+    best = min(cds.ta_hits, key=lambda h: h.evalue)
+    info = hmm_db_info.get(best.ta_name)
+    if info is None:
+        return None
+    return info.get("type")  # "Toxin" or "Antitoxin"
+
+
+def _best_tadb3_toxin_family(cds: Cds, hmm_db_info: HmmDbInfo) -> Optional[str]:
+    """Return the TADB3 toxin HMM profile name (= family ID) for *cds*.
+
+    Only considers hits against TADB3 toxin profiles.  Returns *None* if
+    the gene has no TADB3 toxin hit.
+    """
+    tadb3_toxin_hits = [
+        h
+        for h in cds.ta_hits
+        if h.ta_name in hmm_db_info
+        and hmm_db_info[h.ta_name].get("source") == "TADB3"
+        and hmm_db_info[h.ta_name].get("type") == "Toxin"
+    ]
+    if not tadb3_toxin_hits:
+        return None
+    return min(tadb3_toxin_hits, key=lambda h: h.evalue).ta_name
+
+
+def _best_tadb3_at_family(cds: Cds, hmm_db_info: HmmDbInfo) -> Optional[str]:
+    """Return the TADB3 antitoxin HMM profile name (= family ID) for *cds*.
+
+    Only considers hits against TADB3 antitoxin profiles.  Returns *None* if
+    the gene has no TADB3 antitoxin hit.
+    """
+    tadb3_at_hits = [
+        h
+        for h in cds.ta_hits
+        if h.ta_name in hmm_db_info
+        and hmm_db_info[h.ta_name].get("source") == "TADB3"
+        and hmm_db_info[h.ta_name].get("type") == "Antitoxin"
+    ]
+    if not tadb3_at_hits:
+        return None
+    return min(tadb3_at_hits, key=lambda h: h.evalue).ta_name
+
+
+def _z_score(value: float, mean: float, std: float) -> Optional[float]:
+    if std == 0.0:
+        return None
+    return (value - mean) / std
+
+
+def _round_optional(value: Optional[float], ndigits: int = 3) -> Optional[float]:
+    return None if value is None else round(value, ndigits)
+
+
+# ---------------------------------------------------------------------------
+# Cluster scoring
+# ---------------------------------------------------------------------------
+
+def score_cluster(
+    cluster: GeneCluster,
+    hmm_db_info: HmmDbInfo,
+    ref_stats: RefStats,
+    known_pairs: Optional[KnownPairs] = None,
+) -> Dict[str, Any]:
+    """Compute family-aware robust Z-score features for a two-gene *cluster*.
+
+    Returns a dict with keys:
+        matched_family          – family used for look-up (or ``"__global__"``)
+        n_reference_pairs       – number of reference pairs in that family
+        toxin_size_z            – robust Z-score of toxin amino-acid length
+        at_size_z               – robust Z-score of antitoxin amino-acid length
+        intergenic_distance_z   – robust Z-score of intergenic distance
+        pair_is_known           – 1/0 if (toxin, AT) pair is in TADB3; None if
+                                  family identity is unavailable or known_pairs
+                                  was not provided
+        score                   – unified match score in (0, 1]:
+                                  ``exp(−mean(|z_structural| + z_compat))``
+                                  where z_compat = 0 (known), COMPAT_PENALTY
+                                  (unknown), or excluded (None)
+
+    Scores use median + MAD internally: ``z = (x − median) / (MAD / 0.6745)``.
+    This is robust to the non-normal (right-skewed) size distributions that
+    are common across TA families.  If MAD = 0 for a feature, std is used
+    instead.  If std = 0 as well, that feature returns *None*.
+
+    All numeric fields are *None* when scoring cannot proceed (cluster has
+    no identifiable toxin+antitoxin pair).  For clusters with more than one
+    toxin or antitoxin, all (toxin, antitoxin) combinations are scored and
+    the best-scoring pair is returned.
+    """
+    null_result: Dict[str, Any] = {
+        "matched_family": None,
+        "n_reference_pairs": None,
+        "toxin_size_z": None,
+        "at_size_z": None,
+        "intergenic_distance_z": None,
+        "pair_is_known": None,
+        "score": None,
+    }
+
+    genes = list(cluster.genes)
+    types = [get_gene_type(g, hmm_db_info) for g in genes]
+    toxins: List[Cds] = [g for g, t in zip(genes, types) if t == "Toxin"]
+    antitoxins: List[Cds] = [g for g, t in zip(genes, types) if t == "Antitoxin"]
+
+    if not toxins or not antitoxins:
+        return null_result
+
+    best: Optional[Dict[str, Any]] = None
+    for toxin, antitoxin in itertools.product(toxins, antitoxins):
+        result = score_pair(toxin, antitoxin, hmm_db_info, ref_stats, known_pairs)
+        if best is None or (
+            result["score"] is not None
+            and (best["score"] is None or result["score"] > best["score"])
+        ):
+            best = result
+    return best if best is not None else null_result
+
+
+def score_pair(
+    toxin: Cds,
+    antitoxin: Cds,
+    hmm_db_info: HmmDbInfo,
+    ref_stats: RefStats,
+    known_pairs: Optional[KnownPairs] = None,
+) -> Dict[str, Any]:
+    """Score a single (toxin, antitoxin) gene pair."""
+    # Protein length in amino acids from 1-based inclusive nucleotide coordinates
+    toxin_size = (toxin.stop - toxin.start + 1) // 3
+    at_size = (antitoxin.stop - antitoxin.start + 1) // 3
+
+    # Intergenic distance (negative = overlap), matching reference formula:
+    # downstream.genomic_left − upstream.genomic_right
+    if toxin.start <= antitoxin.start:
+        upstream, downstream = toxin, antitoxin
+    else:
+        upstream, downstream = antitoxin, toxin
+    intergenic_distance = downstream.start - upstream.stop
+
+    # Family look-up: use toxin's best TADB3 hit as family ID
+    family = _best_tadb3_toxin_family(toxin, hmm_db_info)
+    if not family or family not in ref_stats:
+        family = GLOBAL_FAMILY
+
+    fam_stats: Dict[str, Any] = ref_stats.get(family, {})
+
+    # Z-scores
+    def _z(value: float, feat: str) -> Optional[float]:
+        if feat not in fam_stats:
+            return None
+        mean, std = fam_stats[feat]
+        return _z_score(value, mean, std)
+
+    z_toxin = _z(float(toxin_size), "toxin_size")
+    z_at = _z(float(at_size), "at_size")
+    z_intergenic = _z(float(intergenic_distance), "intergenic_distance")
+
+    # Compatibility term: is this (toxin_family, at_family) a known TADB3 pair?
+    pair_is_known: Optional[int] = None
+    z_compat: Optional[float] = None
+    if known_pairs is not None:
+        toxin_family_id = _best_tadb3_toxin_family(toxin, hmm_db_info)
+        at_family_id = _best_tadb3_at_family(antitoxin, hmm_db_info)
+        if toxin_family_id is not None and at_family_id is not None:
+            pair_is_known = 1 if (toxin_family_id, at_family_id) in known_pairs else 0
+            z_compat = 0.0 if pair_is_known == 1 else COMPAT_PENALTY
+
+    # Unified score: exp(−mean(|z_i|)) over all available terms
+    # z_compat is excluded when family identity is unavailable (stays None)
+    z_terms = [abs(z) for z in (z_toxin, z_at, z_intergenic) if z is not None]
+    if z_compat is not None:
+        z_terms.append(z_compat)
+    score: Optional[float] = (
+        round(math.exp(-sum(z_terms) / len(z_terms)), 4) if z_terms else None
+    )
+
+    return {
+        "matched_family": family,
+        "n_reference_pairs": fam_stats.get("n_pairs"),
+        "toxin_size_z": _round_optional(z_toxin),
+        "at_size_z": _round_optional(z_at),
+        "intergenic_distance_z": _round_optional(z_intergenic),
+        "pair_is_known": pair_is_known,
+        "score": score,
+    }

--- a/tatouscan/scoring.py
+++ b/tatouscan/scoring.py
@@ -73,6 +73,7 @@ COMPAT_PENALTY = 2.0
 # Loading reference data
 # ---------------------------------------------------------------------------
 
+
 def load_reference_statistics(path: Path) -> RefStats:
     """Load per-family reference statistics from *tadb3_family_statistics.tsv*.
 
@@ -105,14 +106,14 @@ def load_reference_statistics(path: Path) -> RefStats:
             for feat in SCORED_FEATURES:
                 if has_robust:
                     center = float(row[f"{feat}_median"])
-                    mad    = float(row[f"{feat}_mad"])
-                    scale  = mad / MAD_CONSISTENCY
+                    mad = float(row[f"{feat}_mad"])
+                    scale = mad / MAD_CONSISTENCY
                     if scale == 0.0:
                         # MAD=0: all values identical — fall back to std
                         scale = float(row.get(f"{feat}_std", 0.0))
                 else:
                     center = float(row[f"{feat}_mean"])
-                    scale  = float(row[f"{feat}_std"])
+                    scale = float(row[f"{feat}_std"])
                 entry[feat] = (center, scale)
             entry["n_pairs"] = int(row["n_pairs"])
             stats[family] = entry
@@ -136,6 +137,7 @@ def load_known_pairs(path: Path) -> KnownPairs:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def get_gene_type(cds: Cds, hmm_db_info: HmmDbInfo) -> Optional[str]:
     """Return the type string (``"Toxin"`` or ``"Antitoxin"``) for *cds*."""
@@ -197,6 +199,7 @@ def _round_optional(value: Optional[float], ndigits: int = 3) -> Optional[float]
 # ---------------------------------------------------------------------------
 # Cluster scoring
 # ---------------------------------------------------------------------------
+
 
 def score_cluster(
     cluster: GeneCluster,

--- a/tatouscan/system.py
+++ b/tatouscan/system.py
@@ -3,7 +3,6 @@ import logging
 
 from tatouscan.models import Cds
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tatouscan/writer.py
+++ b/tatouscan/writer.py
@@ -260,7 +260,7 @@ def write_pairs_with_ta_annotation(
     pairs_written = 0
     skipped = 0
 
-    with open(output_file, "w") as fl:
+    with open(output_file, "w", newline="") as fl:
         writer = None
 
         for cluster_id, cluster in sorted(clusters.items()):

--- a/tatouscan/writer.py
+++ b/tatouscan/writer.py
@@ -163,7 +163,7 @@ def write_gene_with_ta_annotation(
         if detailed
         else {k: v for k, v in _SCORE_NULL_FULL.items() if k not in _SCORE_DETAIL_KEYS}
     )
-    with open(output_file, "w") as fl:
+    with open(output_file, "w", newline="") as fl:
         writer = None
         for contig_name, cdss in contig_name_and_cdss_with_ta_hit:
             for cds in cdss:

--- a/tatouscan/writer.py
+++ b/tatouscan/writer.py
@@ -1,11 +1,53 @@
-from typing import Any, Generator, Dict, List, Set
+from typing import Any, Generator, Dict, List, Optional
 
-from tatouscan.models import Cds, TaHit
+from tatouscan.models import Cds, GeneCluster, TaHit
 from pathlib import Path
 import csv
+import itertools
 import logging
 
+from tatouscan.scoring import (
+    get_gene_type,
+    score_cluster,
+    score_pair,
+    RefStats,
+    KnownPairs,
+)
+
 logger = logging.getLogger(__name__)
+
+# Score keys that are only written in --detailed mode
+_SCORE_DETAIL_KEYS: frozenset[str] = frozenset(
+    {
+        "matched_family",
+        "n_reference_pairs",
+        "toxin_size_z",
+        "at_size_z",
+        "intergenic_distance_z",
+    }
+)
+
+# Pairs-file columns omitted in default (non-detailed) output
+_PAIRS_DETAIL_KEYS: frozenset[str] = frozenset(
+    {
+        "toxin_start",
+        "toxin_end",
+        "antitoxin_start",
+        "antitoxin_end",
+        "toxin_gene_type",
+        "antitoxin_gene_type",
+    }
+)
+
+_SCORE_NULL_FULL: Dict[str, Any] = {
+    "matched_family": None,
+    "n_reference_pairs": None,
+    "toxin_size_z": None,
+    "at_size_z": None,
+    "intergenic_distance_z": None,
+    "pair_is_known": None,
+    "score": None,
+}
 
 
 def get_best_hit(ta_hits: List[TaHit], hmm_db_info: Dict[str, Dict[str, str]]):
@@ -38,6 +80,22 @@ def get_best_hit(ta_hits: List[TaHit], hmm_db_info: Dict[str, Dict[str, str]]):
         ]
 
     return hit_info
+
+
+def _summarise_ta_hits_simple(
+    ta_hits: List[TaHit], hmm_db_info: Dict[str, Dict[str, str]]
+) -> Dict[str, Any]:
+    """Return gene type and the single best HMM hit across all database sources."""
+    best_hit = min(ta_hits, key=lambda hit: hit.evalue)
+    info = hmm_db_info.get(best_hit.ta_name, {})
+    return {
+        "gene_type": info.get("type"),
+        "hmm_name": best_hit.ta_name,
+        "hmm_score": best_hit.score,
+        "hmm_evalue": best_hit.evalue,
+        "hmm_source": info.get("source"),
+        "hmm_description": info.get("supplementary_info"),
+    }
 
 
 def summarise_ta_hits(ta_hits: List[TaHit], hmm_db_info: Dict[str, Dict[str, str]]):
@@ -87,14 +145,24 @@ def write_gene_with_ta_annotation(
     contig_name_and_cdss_with_ta_hit: Generator[tuple[str, list[Cds]], Any, None],
     hmm_db_info: Dict[str, Dict[str, str]],
     output_file: Path,
+    ref_stats: Optional[RefStats] = None,
+    known_pairs: Optional[KnownPairs] = None,
+    output_pairs_file: Optional[Path] = None,
+    detailed: bool = False,
 ):
     """
     Write the gene with TA annotation to a file.
     """
 
-    gene_clusters: Set[int] = set()
+    cluster_objects: Dict[int, GeneCluster] = {}  # cluster_id → GeneCluster
     single_genes_count = 0
     gene_in_cluster_count = 0
+    cluster_score_cache: Dict[int, Dict[str, Any]] = {}  # cluster_id → score dict
+    _score_null = (
+        _SCORE_NULL_FULL
+        if detailed
+        else {k: v for k, v in _SCORE_NULL_FULL.items() if k not in _SCORE_DETAIL_KEYS}
+    )
     with open(output_file, "w") as fl:
         writer = None
         for contig_name, cdss in contig_name_and_cdss_with_ta_hit:
@@ -107,21 +175,47 @@ def write_gene_with_ta_annotation(
                 ta_gene_info["start"] = cds.start
                 ta_gene_info["end"] = cds.stop
                 ta_gene_info["strand"] = cds.strand.value
+                ta_gene_info["length_aa"] = (cds.stop - cds.start + 1) // 3
                 ta_gene_info["product"] = cds.product
 
                 if cds.ta_cluster:
                     ta_gene_info["ta_system_id"] = cds.ta_cluster.id
                     ta_gene_info["is_single_gene"] = False
-                    gene_clusters.add(cds.ta_cluster.id)
+                    cluster_objects[cds.ta_cluster.id] = cds.ta_cluster
                     gene_in_cluster_count += 1
                 else:
                     ta_gene_info["is_single_gene"] = True
                     ta_gene_info["ta_system_id"] = None
                     single_genes_count += 1
 
-                hit_info = summarise_ta_hits(cds.ta_hits, hmm_db_info)
+                hit_info = (
+                    summarise_ta_hits(cds.ta_hits, hmm_db_info)
+                    if detailed
+                    else _summarise_ta_hits_simple(cds.ta_hits, hmm_db_info)
+                )
 
                 ta_gene_info.update(hit_info)
+
+                if ref_stats is not None:
+                    if cds.ta_cluster:
+                        cid = cds.ta_cluster.id
+                        if cid not in cluster_score_cache:
+                            cluster_score_cache[cid] = score_cluster(
+                                cds.ta_cluster,
+                                hmm_db_info,
+                                ref_stats,
+                                known_pairs=known_pairs,
+                            )
+                        score_dict = cluster_score_cache[cid]
+                        if not detailed:
+                            score_dict = {
+                                k: v
+                                for k, v in score_dict.items()
+                                if k not in _SCORE_DETAIL_KEYS
+                            }
+                        ta_gene_info.update(score_dict)
+                    else:
+                        ta_gene_info.update(_score_null)
 
                 if writer is None:
                     writer = csv.DictWriter(
@@ -133,7 +227,133 @@ def write_gene_with_ta_annotation(
 
     logger.info(f"Finished writing genes with TA annotations to file '{output_file}'")
     logger.info(
-        f"Identified {len(gene_clusters)} gene groups with TA annotations, "
+        f"Identified {len(cluster_objects)} gene groups with TA annotations, "
         f"containing a total of {gene_in_cluster_count} genes."
     )
     logger.info(f"Identified {single_genes_count} single genes with TA annotations.")
+
+    if output_pairs_file is not None:
+        write_pairs_with_ta_annotation(
+            cluster_objects,
+            hmm_db_info,
+            output_pairs_file,
+            ref_stats=ref_stats,
+            known_pairs=known_pairs,
+            detailed=detailed,
+        )
+
+
+def write_pairs_with_ta_annotation(
+    clusters: Dict[int, GeneCluster],
+    hmm_db_info: Dict[str, Dict[str, str]],
+    output_file: Path,
+    ref_stats: Optional[RefStats] = None,
+    known_pairs: Optional[KnownPairs] = None,
+    detailed: bool = False,
+):
+    """Write one TSV row per valid (toxin, antitoxin) pair across all clusters.
+
+    For clusters with more than one toxin or antitoxin, all combinations are
+    written as individual rows, each independently scored.
+    Clusters with no identifiable toxin or antitoxin gene are skipped.
+    """
+    pairs_written = 0
+    skipped = 0
+
+    with open(output_file, "w") as fl:
+        writer = None
+
+        for cluster_id, cluster in sorted(clusters.items()):
+            genes = list(cluster.genes)
+            types = [get_gene_type(g, hmm_db_info) for g in genes]
+
+            toxins = [g for g, t in zip(genes, types) if t == "Toxin"]
+            antitoxins = [g for g, t in zip(genes, types) if t == "Antitoxin"]
+
+            if not toxins or not antitoxins:
+                skipped += 1
+                continue
+
+            for toxin, antitoxin in itertools.product(toxins, antitoxins):
+                # Contig (both genes share the same contig in a cluster)
+                contig_name = toxin.contig_id
+
+                # Structural features
+                toxin_length_aa = (toxin.stop - toxin.start + 1) // 3
+                antitoxin_length_aa = (antitoxin.stop - antitoxin.start + 1) // 3
+
+                upstream = toxin if toxin.start <= antitoxin.start else antitoxin
+                downstream = antitoxin if toxin.start <= antitoxin.start else toxin
+                intergenic_distance = downstream.start - upstream.stop
+
+                # HMM hit summaries per gene
+                _hit_fn = summarise_ta_hits if detailed else _summarise_ta_hits_simple
+                toxin_hits = _hit_fn(toxin.ta_hits, hmm_db_info)
+                antitoxin_hits = _hit_fn(antitoxin.ta_hits, hmm_db_info)
+
+                row: Dict[str, Any] = {
+                    "ta_system_id": cluster_id,
+                    "contig_name": contig_name,
+                    "toxin_gene_id": toxin.id,
+                    "toxin_start": toxin.start,
+                    "toxin_end": toxin.stop,
+                    "toxin_strand": toxin.strand.value,
+                    "toxin_product": toxin.product,
+                    "toxin_length_aa": toxin_length_aa,
+                }
+                row.update({f"toxin_{k}": v for k, v in toxin_hits.items()})
+
+                row["antitoxin_gene_id"] = antitoxin.id
+                row["antitoxin_start"] = antitoxin.start
+                row["antitoxin_end"] = antitoxin.stop
+                row["antitoxin_strand"] = antitoxin.strand.value
+                row["antitoxin_product"] = antitoxin.product
+                row["antitoxin_length_aa"] = antitoxin_length_aa
+                row.update({f"antitoxin_{k}": v for k, v in antitoxin_hits.items()})
+
+                row["intergenic_distance"] = intergenic_distance
+
+                if ref_stats is not None:
+                    score_info = score_pair(
+                        toxin,
+                        antitoxin,
+                        hmm_db_info,
+                        ref_stats,
+                        known_pairs=known_pairs,
+                    )
+                    if not detailed:
+                        score_info = {
+                            k: v
+                            for k, v in score_info.items()
+                            if k not in _SCORE_DETAIL_KEYS
+                        }
+                    row.update(score_info)
+                else:
+                    _pair_score_null = (
+                        _SCORE_NULL_FULL
+                        if detailed
+                        else {
+                            k: v
+                            for k, v in _SCORE_NULL_FULL.items()
+                            if k not in _SCORE_DETAIL_KEYS
+                        }
+                    )
+                    row.update(_pair_score_null)
+
+                if not detailed:
+                    row = {k: v for k, v in row.items() if k not in _PAIRS_DETAIL_KEYS}
+
+                if writer is None:
+                    writer = csv.DictWriter(fl, fieldnames=row.keys(), delimiter="\t")
+                    writer.writeheader()
+
+                writer.writerow(row)
+                pairs_written += 1
+
+    logger.info(
+        f"Finished writing TA pairs to '{output_file}' ({pairs_written} pairs written)."
+    )
+    if skipped:
+        logger.info(
+            f"Skipped {skipped} clusters with no identifiable toxin or antitoxin gene."
+        )

--- a/tests/annotation_test.py
+++ b/tests/annotation_test.py
@@ -23,11 +23,9 @@ def faa_file(tmp_path: Path) -> Path:
     Fixture for a protein FASTA file.
     """
     faa_file: Path = tmp_path / "test.faa"
-    faa_file.write_text(
-        """>protein1
+    faa_file.write_text(""">protein1
     MTEITAAMVKELRESTGAGMMDCKNALSETQHEFSQVLKAKLAEQAERYDDMAAAMKAVTEQGHELSNEER
-    """
-    )
+    """)
     return faa_file
 
 
@@ -37,15 +35,13 @@ def hmm_db(tmp_path: Path) -> Path:
     Fixture for an HMM database file.
     """
     hmm_db: Path = tmp_path / "test.hmm"
-    hmm_db.write_text(
-        """HMMER3/f [3.1b2 | March 2015]
+    hmm_db.write_text("""HMMER3/f [3.1b2 | March 2015]
     NAME  TestHMM
     ACC   TEST00001
     DESC  Test HMM
     LENG  50
     ALPH  amino
-    """
-    )
+    """)
     return hmm_db
 
 


### PR DESCRIPTION
This PR introduces a match score for every predicted toxin–antitoxin pair, along with a second output file and several usability improvements.

### Scoring

Each pair is scored by comparing three structural features — toxin size, antitoxin size, and intergenic distance — against reference statistics derived from known TADB3 systems. Robust Z-scores (median + MAD) are used to handle the non-normal size distributions common in TA families. A compatibility term is added when the toxin–antitoxin family combination has not been observed in TADB3. All terms are combined into a single score in `(0, 1]`:

```
score = exp(−mean(|z_i|))
```

Family-specific statistics are used when available; a global fallback is applied for unrecognised or rare families.

### Changes

- **New output file** `tatouscan_results_pairs.tsv`: one row per predicted pair, with gene annotations, protein lengths, intergenic distance, and the pair score.
- **Multi-gene systems**: clusters with more than one toxin or antitoxin are now handled — the best-scoring pair is reported in the per-gene file, all combinations appear in the pairs file.
- **`--db` flag**: replaces separate arguments for HMM and statistics files with a single database directory.
- **`--detailed` flag**: by default only the best HMM hit and final score are written; `--detailed` restores per-source HMM columns and raw Z-score columns.